### PR TITLE
replace outdated MxNet API

### DIFF
--- a/MxNet/Classification/RN50v1.5/fit.py
+++ b/MxNet/Classification/RN50v1.5/fit.py
@@ -377,7 +377,7 @@ def fit(args, network, data_loader, **kwargs):
             self.tic = 0
 
         def gather_metrics(self, data):
-            params = dict(data.eval_metric.get_global_name_value())
+            params = dict(data.eval_metric.get_name_value())
 
             if self.num != 0:
                 self.time += time.time() - self.tic


### PR DESCRIPTION
For `data.eval_metric.get_gloabl_name_value()`, MxNet `EvalMetric` API changes it to `get_name_value()`