### PR TITLE
Include jupyter in this docker build

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/docker/Dockerfile
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV PATH=$CONDA_PREFIX/bin:$PATH
 ENV CONDA_AUTO_UPDATE_CONDA=false
 
 RUN conda install -y ipython
-RUN pip install ninja yacs cython matplotlib opencv-python
+RUN pip install ninja yacs cython matplotlib opencv-python jupyter
 
 # Install PyTorch 1.0 Nightly and OpenCV
 RUN conda install -y pytorch-nightly -c pytorch \


### PR DESCRIPTION
Simply include jupyter in this docker image, so we don't need to build a separate docker image just for jupyter