### PR TITLE
Fix An Error When Running Test (Transformer)

### DIFF
--- a/PyTorch/Translation/Transformer/README.md
+++ b/PyTorch/Translation/Transformer/README.md
@@ -117,7 +117,7 @@ python interactive.py --buffer-size 1 --fp16 --path /path/to/your/checkpoint.pt 
         --fuse-dropout-add --remove-bpe --bpe-codes /path/to/code/file \
         /path/to/dataset/wmt14_en_de_joined_dict/ < wmt14-en-de.src > wmt14.detok
 grep ^H wmt14.detok | cut -f3- > wmt14.translated
-cat wmt14.translated | sacrebleu -t wmt14 -lc -l en-de
+cat wmt14.translated | sacrebleu -t wmt14/full -lc -l en-de
 ```
 Sacrebleu test set is a subset of test set used during a course of training thus score obtained with sacreBLEU can slightly differ from the one computed during training.
 


### PR DESCRIPTION
Running "cat wmt14.translated | sacrebleu -t wmt14 -lc -l en-de" will cause a problem:

sacreBLEU: Downloading http://statmt.org/wmt14/test-filtered.tgz to /root/.sacrebleu/wmt14/test-filtered.tgz
sacreBLEU: Extracting /root/.sacrebleu/wmt14/test-filtered.tgz
sacreBLEU: Processing /root/.sacrebleu/wmt14/raw/test/newstest2014-deen-src.en.sgm to /root/.sacrebleu/wmt14/en-de.en
sacreBLEU: Processing /root/.sacrebleu/wmt14/raw/test/newstest2014-deen-ref.de.sgm to /root/.sacrebleu/wmt14/en-de.de
sacreBLEU: The input and reference stream(s) were of different lengths.

sacreBLEU: This could be a problem with your system output or with sacreBLEU's reference database.
If the latter, you can clean out the references cache by typing:

    rm -r /root/.sacrebleu/wmt14

They will be downloaded automatically again the next time you run sacreBLEU.

It should be fixed as: "cat wmt14.translated | sacrebleu -t wmt14/full -lc -l en-de"

sacreBLEU: Creating /root/.sacrebleu/wmt14/full
sacreBLEU: Downloading http://statmt.org/wmt14/test-full.tgz to /root/.sacrebleu/wmt14/full/test-full.tgz
sacreBLEU: Extracting /root/.sacrebleu/wmt14/full/test-full.tgz
sacreBLEU: Processing /root/.sacrebleu/wmt14/full/raw/test-full/newstest2014-deen-src.en.sgm to /root/.sacrebleu/wmt14/full/en-de.en
sacreBLEU: Processing /root/.sacrebleu/wmt14/full/raw/test-full/newstest2014-deen-ref.de.sgm to /root/.sacrebleu/wmt14/full/en-de.de
BLEU+case.lc+lang.en-de+numrefs.1+smooth.exp+test.wmt14/full+tok.13a+version.1.2.10 = 27.44 58.8/33.1/21.0/13.9 (BP = 1.000 ratio = 1.043 hyp_len = 65360 ref_len = 62688)