### PR TITLE
[fix] fix 'std::runtime_error' issue

### DIFF
--- a/FasterTransformer/fastertransformer/common.h
+++ b/FasterTransformer/fastertransformer/common.h
@@ -19,6 +19,7 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cublas_v2.h>
+#include <stdexcept>
 
 namespace fastertransformer{
 


### PR DESCRIPTION
 error: ‘runtime_error’ in namespace ‘std’ does not name a type