### PR TITLE
[TensorFlow/Detection/SSD][issue #102] use dataset preprocessing script from tensorflow/object_detection

### DIFF
--- a/TensorFlow/Detection/SSD/download_all.sh
+++ b/TensorFlow/Detection/SSD/download_all.sh
@@ -21,10 +21,6 @@ COCO_DIR=${2:-"/data/coco2017_tfrecords"}
 CHECKPOINT_DIR=${3:-"/checkpoints"}
 mkdir -p $COCO_DIR
 chmod 777 $COCO_DIR
-cd $COCO_DIR
-curl -O http://images.cocodataset.org/zips/train2017.zip; unzip train2017.zip
-curl -O http://images.cocodataset.org/zips/val2017.zip; unzip val2017.zip
-curl -O http://images.cocodataset.org/annotations/annotations_trainval2017.zip; unzip annotations_trainval2017.zip
 # Download backbone checkpoint
 mkdir -p $CHECKPOINT_DIR
 chmod 777 $CHECKPOINT_DIR
@@ -34,13 +30,6 @@ tar -xzf resnet_v1_50_2016_08_28.tar.gz
 mkdir -p resnet_v1_50
 mv resnet_v1_50.ckpt resnet_v1_50/model.ckpt
 nvidia-docker run --rm -it -u 123 -v $COCO_DIR:/data/coco2017_tfrecords $CONTAINER bash -c '
-cd /data/coco2017_tfrecords
 # Create TFRecords
-python /workdir/models/research/object_detection/dataset_tools/create_coco_tf_record.py \
-    --train_image_dir=`pwd`"/train2017" \
-    --val_image_dir=`pwd`"/val2017" \
-    --val_annotations_file=`pwd`"/annotations/instances_val2017.json" \
-    --train_annotations_file=`pwd`"/annotations/instances_train2017.json" \
-    --testdev_annotations_file=`pwd`"/annotations/instances_val2017.json" \
-    --test_image_dir=`pwd`"/val2017" \
-    --output_dir=`pwd`'
+bash /workdir/models/research/object_detection/dataset_tools/download_and_preprocess_mscoco.sh \
+    /data/coco2017_tfrecords'


### PR DESCRIPTION
In response to issue #102 

Without this change, SSD training is terminated with error:
```
tensorflow.python.framework.errors_impl.DataLossError: corrupted record at 0
[[{{node IteratorGetNext}}]]
[[{{node IteratorGetNext}}]]
```
because the dataset prepared by `download_all.sh` script is invalid.