### PR TITLE
Fix misleading unused model_state variable in build_resnet()

### DIFF
--- a/PyTorch/Classification/RN50v1.5/image_classification/resnet.py
+++ b/PyTorch/Classification/RN50v1.5/image_classification/resnet.py
@@ -268,4 +268,7 @@ def build_resnet(version, config, model_state=None):
                            version['layers'],
                            version['num_classes'])
 
+    if model_state:
+        model.load_state_dict(model_state)
+    
     return model


### PR DESCRIPTION
Hi,

`model_state` being unused in this function caused incorrect results for my model and this took me a while to figure out. 

I think it would be helpful if this argument was either updated to be used or removed completely.

Thanks,
Ryan