### PR TITLE
Disable grappler memory optimizations when XLA is active

### DIFF
--- a/TensorFlow/LanguageModeling/BERT/run_pretraining.py
+++ b/TensorFlow/LanguageModeling/BERT/run_pretraining.py
@@ -24,6 +24,8 @@ import modeling
 import optimization
 import tensorflow as tf
 
+from tensorflow.core.protobuf import rewriter_config_pb2
+
 flags = tf.flags
 
 FLAGS = flags.FLAGS
@@ -467,6 +469,7 @@ def main(_):
         raise ValueError("Input Files must be sharded")
   if FLAGS.use_xla: 
     config.graph_options.optimizer_options.global_jit_level = tf.OptimizerOptions.ON_1
+    config.graph_options.rewrite_options.memory_optimization = rewriter_config_pb2.RewriterConfig.NO_MEM_OPT
   is_per_host = tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2
   config = tf.ConfigProto()
   if FLAGS.horovod:


### PR DESCRIPTION
I learned from Trent Lo that disabling Grappler memory optimizations can improve throughput when XLA is active. This is most effective when you are close to fully utilizing GPU memory, throughput nearly doubles for batch size 64 training with sequence length 128 on a 32GB V100. Disabling grappler memory optimizations also reduces startup time by about 10%.