### PR TITLE
fix the wrong rank used in DataGenerator

### DIFF
--- a/TensorFlow/Recommendation/NCF/ncf.py
+++ b/TensorFlow/Recommendation/NCF/ncf.py
@@ -219,7 +219,7 @@ def main():
     # Create and run Data Generator in a separate thread
     data_generator = DataGenerator(
         args.seed,
-        hvd.rank(),
+        hvd.local_rank(),
         nb_users,
         nb_items,
         neg_mat,


### PR DESCRIPTION
hvd.rank() is correct only if all gpus are within a single machine, otherwise the following error will occur
```
Traceback (most recent call last):
  File "nvidia-DeepLearningExamples/TensorFlow/Recommendation/NCF/ncf.py", line 470, in <module>
    main()
  File "nvidia-DeepLearningExamples/TensorFlow/Recommendation/NCF/ncf.py", line 234, in main
    args.valid_negative,
  File "nvidia-DeepLearningExamples/TensorFlow/Recommendation/NCF/input_pipeline.py", line 73, in __init__
    cp.cuda.Device(self.hvd_rank).use()
  File "cupy/cuda/device.pyx", line 135, in cupy.cuda.device.Device.use
  File "cupy/cuda/device.pyx", line 141, in cupy.cuda.device.Device.use
  File "cupy/cuda/runtime.pyx", line 193, in cupy.cuda.runtime.setDevice
  File "cupy/cuda/runtime.pyx", line 145, in cupy.cuda.runtime.check_status
cupy.cuda.runtime.CUDARuntimeError: cudaErrorInvalidDevice: invalid device ordinal
```
The correct way should be passing `hvd.local_rank()` .