### PR TITLE
[FasterTransformer] fix gpu memory thread safety problem for tensorflow BertTransformerOp

### DIFF
--- a/FasterTransformer/fastertransformer/bert_encoder_transformer.h
+++ b/FasterTransformer/fastertransformer/bert_encoder_transformer.h
@@ -90,7 +90,7 @@ class BertEncoderTransformerTraits<OperationType::HALF, MultiHeadAttention_>
 template<class Traits_>
 class BertEncoderTransformer:IEncoderTransformer<Traits_::OpType>
 {
-  const IAllocator& allocator_;
+  IAllocator& allocator_;
   typename Traits_::MultiHeadAttention *attention_;
   typedef typename Traits_::DataType DataType_;
   EncoderInitParam<DataType_> param_;
@@ -112,7 +112,7 @@ class BertEncoderTransformer:IEncoderTransformer<Traits_::OpType>
   int head_num_;
   int size_per_head_;
   public:
-  BertEncoderTransformer(const IAllocator& allocator, int batch_size, int from_seq_len, 
+  BertEncoderTransformer(IAllocator& allocator, int batch_size, int from_seq_len,
       int to_seq_len, int head_num, int size_per_head): 
     allocator_(allocator), batch_size_(batch_size), from_seq_len_(from_seq_len),
     to_seq_len_(to_seq_len), head_num_(head_num), size_per_head_(size_per_head){

--- a/FasterTransformer/fastertransformer/cuda/open_attention.h
+++ b/FasterTransformer/fastertransformer/cuda/open_attention.h
@@ -68,7 +68,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
   const cudaDataType_t AType_ = Traits_::AType;
   const cudaDataType_t BType_ = Traits_::BType;
   const cudaDataType_t CType_ = Traits_::CType;
-  const IAllocator& allocator_;
+  IAllocator& allocator_;
   MultiHeadInitParam<DataType_> param_;
 
   int cublasAlgo_[3];
@@ -91,7 +91,7 @@ class OpenMultiHeadAttention: IMultiHeadAttention<OpType_>
   int size_per_head_;
  public:
   //Ctor
-  OpenMultiHeadAttention(const IAllocator& allocator, int batch_size, int from_seq_len, 
+  OpenMultiHeadAttention(IAllocator& allocator, int batch_size, int from_seq_len,
       int to_seq_len, int head_num, int size_per_head): 
     allocator_(allocator), batch_size_(batch_size), from_seq_len_(from_seq_len), to_seq_len_(to_seq_len), 
     head_num_(head_num), size_per_head_(size_per_head)

--- a/FasterTransformer/fastertransformer/tf_op/bert_transformer_op.cc
+++ b/FasterTransformer/fastertransformer/tf_op/bert_transformer_op.cc
@@ -93,9 +93,9 @@ class BertTransformerOp : public OpKernel
     {
       typedef BertEncoderTransformerTraits<traits_::OpType, cuda::OpenMultiHeadAttention> EncoderTraits_;
       BertEncoderTransformer<EncoderTraits_> *encoder_transformer_;
+      fastertransformer::Allocator<AllocatorType::TF> allocator_(context);
       try
       {
-        fastertransformer::Allocator<AllocatorType::TF> allocator_(context);
         encoder_transformer_ = new BertEncoderTransformer<EncoderTraits_>(allocator_, 
           batch_size_, from_seq_len_, to_seq_len_, head_num_, size_per_head_);
       }


### PR DESCRIPTION
There is a thread safety problem in the current implementation of BertTransformerOp.

**Tensorflow tracks each tensor's ref counts, and will deallocate the gpu memory the tensor holds when Tensor deconstructed from stack.** In the current implementation, as the Tensor is allocated on the stack, the Tensor's life time only lies in Allocator::free() function, and Tensorflow will recycle the gpu memory as soon as Allocator::free() finished.

It works well when there's only one thread running, **but it causes multiple operations contending the same gpu memory when there are multiple threads running, which is the common case of Tensorflow serving.**
