### PR TITLE
added kwargs when loading tacotron and waveglow

### DIFF
--- a/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py
+++ b/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py
@@ -530,8 +530,8 @@ class Decoder(nn.Module):
 
         self.initialize_decoder_states(memory, mask=None)
 
-        mel_lengths = torch.zeros([memory.size(0)], dtype=torch.int32).cuda()
-        not_finished = torch.ones([memory.size(0)], dtype=torch.int32).cuda()
+        mel_lengths = torch.zeros([memory.size(0)], dtype=torch.int32).cpu()
+        not_finished = torch.ones([memory.size(0)], dtype=torch.int32).cpu()
         mel_outputs, gate_outputs, alignments = [], [], []
         while True:
             decoder_input = self.prenet(decoder_input)

--- a/hubconf.py
+++ b/hubconf.py
@@ -140,7 +140,7 @@ def nvidia_tacotron2(pretrained=True, **kwargs):
         else:
             checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2pyt_fp32/versions/1/files/nvidia_tacotron2pyt_fp32_20190306.pth'
         ckpt_file = _download_checkpoint(checkpoint, force_reload)
-        ckpt = torch.load(ckpt_file)
+        ckpt = torch.load(ckpt_file, **kwargs)
         state_dict = ckpt['state_dict']
         if checkpoint_from_distributed(state_dict):
             state_dict = unwrap_distributed(state_dict)
@@ -197,7 +197,7 @@ def nvidia_waveglow(pretrained=True, **kwargs):
         else:
             checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/waveglowpyt_fp32/versions/1/files/nvidia_waveglowpyt_fp32_20190306.pth'
         ckpt_file = _download_checkpoint(checkpoint, force_reload)
-        ckpt = torch.load(ckpt_file)
+        ckpt = torch.load(ckpt_file, **kwargs)
         state_dict = ckpt['state_dict']
         if checkpoint_from_distributed(state_dict):
             state_dict = unwrap_distributed(state_dict)


### PR DESCRIPTION
An error occurs when trying to load the pretrained Tacotron and Waveglow models on a CPU.
For example:
torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_tacotron2',
                         pretrained=True, map_location=torch.device('cpu'))
throws:
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

Passing along the **kwargs when loading in the hubconf will fix this problem.
