### PR TITLE
Use tf.io.gfile to check if file exists

### DIFF
--- a/TensorFlow/Classification/RN50v1.5/runtime/runner.py
+++ b/TensorFlow/Classification/RN50v1.5/runtime/runner.py
@@ -78,7 +78,7 @@ class Runner(object):
         if n_channels not in [1, 3]:
             raise ValueError("Unsupported number of channels: %d (allowed: 1 (grayscale) and 3 (color))" % n_channels)
 
-        if data_dir is not None and not os.path.exists(data_dir):
+        if data_dir is not None and not tf.io.gfile.exists(data_dir):
             raise ValueError("The `data_dir` received does not exists: %s" % data_dir)
 
         hvd.init()

--- a/TensorFlow/Classification/RN50v1.5/runtime/runner_utils.py
+++ b/TensorFlow/Classification/RN50v1.5/runtime/runner_utils.py
@@ -46,7 +46,7 @@ def list_filenames_in_dataset(data_dir, mode, count=True):
     if mode not in ["train", 'validation']:
         raise ValueError("Unknown mode received: %s" % mode)
 
-    if not os.path.exists(data_dir):
+    if not tf.io.gfile.exists(data_dir):
         raise FileNotFoundError("The data directory: `%s` can't be found" % data_dir)
 
     filename_pattern = os.path.join(data_dir, '%s-*' % mode)


### PR DESCRIPTION
If ImageNet data is not stored locally, e.g. on HDFS. `os.path.exists` check fails, but `tf.io.gfile` works. I have tested in our environment.  