### PR TITLE
Fix [PyT/DLRM] bug of model.py

### DIFF
--- a/PyTorch/Recommendation/DLRM/dlrm/model.py
+++ b/PyTorch/Recommendation/DLRM/dlrm/model.py
@@ -124,7 +124,7 @@ class Dlrm(nn.Module):
             interaction = torch.bmm(concat, torch.transpose(concat, 1, 2))
             interaction_flat = interaction[:, self.tril_indices[0], self.tril_indices[1]]
             # concatenate dense features and interactions
-            interaction_padding = self._interaction_padding.expand(batch_size, 1).to(dtype=bottom_mlp_output.dtype)
+            interaction_padding = self._interaction_padding.expand(batch_size, 1).to(dtype=bottom_mlp_output.dtype).cuda()
             interaction_output = torch.cat(
                 (bottom_mlp_output, interaction_flat, interaction_padding), dim=1)
         elif self._interaction_op == "cat":

--- a/PyTorch/Recommendation/DLRM/dlrm/model.py
+++ b/PyTorch/Recommendation/DLRM/dlrm/model.py
@@ -95,7 +95,7 @@ class Dlrm(nn.Module):
         self.top_mlp = nn.Sequential(*top_mlp_layers)
 
         self._initialize_mlp_weights()
-        self._interaction_padding = torch.zeros(1, 1, dtype=torch.float32)
+        self._interaction_padding = torch.zeros(1, 1, dtype=torch.float32, device=base_device)
         self.tril_indices = torch.tensor([[i for i in range(len(self.embeddings) + 1) 
                                              for j in range(i + int(self_interaction))],
                                           [j for i in range(len(self.embeddings) + 1) 
@@ -124,7 +124,7 @@ class Dlrm(nn.Module):
             interaction = torch.bmm(concat, torch.transpose(concat, 1, 2))
             interaction_flat = interaction[:, self.tril_indices[0], self.tril_indices[1]]
             # concatenate dense features and interactions
-            interaction_padding = self._interaction_padding.expand(batch_size, 1).to(dtype=bottom_mlp_output.dtype).cuda()
+            interaction_padding = self._interaction_padding.expand(batch_size, 1).to(dtype=bottom_mlp_output.dtype)
             interaction_output = torch.cat(
                 (bottom_mlp_output, interaction_flat, interaction_padding), dim=1)
         elif self._interaction_op == "cat":


### PR DESCRIPTION
I executed following command.

```bash
python3 -m dlrm.scripts.main --mode train --max_steps 500 --benchmark_warmup_steps 250 --synthetic_dataset --print_freq 1
```

and got this error.

```bash
(...snip)

Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/root/DeepLearningExamples/PyTorch/Recommendation/DLRM/dlrm/scripts/main.py", line 509, in <module>
    app.run(main)
  File "/usr/local/lib/python3.6/site-packages/absl/app.py", line 299, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.6/site-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))
  File "/root/DeepLearningExamples/PyTorch/Recommendation/DLRM/dlrm/scripts/main.py", line 293, in main
    train(model, loss_fn, optimizer, data_loader_train, data_loader_test, scaled_lr)
  File "/root/DeepLearningExamples/PyTorch/Recommendation/DLRM/dlrm/scripts/main.py", line 355, in train
    output = model(numerical_features, categorical_features).squeeze().float()
  File "/usr/local/lib64/python3.6/site-packages/torch/nn/modules/module.py", line 532, in __call__
    result = self.forward(*input, **kwargs)
  File "/root/DeepLearningExamples/PyTorch/Recommendation/DLRM/dlrm/model.py", line 220, in forward
    interaction_output = self._interaction(bottom_mlp_output, embedding_outputs, batch_size)
  File "/root/DeepLearningExamples/PyTorch/Recommendation/DLRM/dlrm/model.py", line 129, in _interaction
    (bottom_mlp_output, interaction_flat, interaction_padding), dim=1)
RuntimeError: Expected object of backend CUDA but got backend CPU for sequence element 2 in sequence argument at position #1 'tensors'
```

`torch.cat` requires inputs that are on the same device (GPU). I fixed it.