### PR TITLE
Enable resource_var when XLA is on for run_squad.py.

### DIFF
--- a/TensorFlow/LanguageModeling/BERT/run_squad.py
+++ b/TensorFlow/LanguageModeling/BERT/run_squad.py
@@ -965,6 +965,7 @@ def main(_):
           training_hooks.append(hvd.BroadcastGlobalVariablesHook(0))
   if FLAGS.use_xla:
     config.graph_options.optimizer_options.global_jit_level = tf.compat.v1.OptimizerOptions.ON_1
+    tf.enable_resource_variables()
   run_config = tf.estimator.RunConfig(
       model_dir=FLAGS.output_dir if master_process else None,
       session_config=config,


### PR DESCRIPTION

I observed 9% perf gain on 8GPUs and 13% on 1GPU for BERT SQuad fine-tuning (fp16, BS=3, on DGX-1), excluding compilation time.