### PR TITLE
[Tacotron2] fixed get_model in inference.py

### DIFF
--- a/PyTorch/SpeechSynthesis/Tacotron2/inference.py
+++ b/PyTorch/SpeechSynthesis/Tacotron2/inference.py
@@ -109,7 +109,7 @@ def load_and_setup_model(model_name, parser, checkpoint, fp16_run, cpu_run, forw
     model_parser = models.parse_model_args(model_name, parser, add_help=False)
     model_args, _ = model_parser.parse_known_args()
     model_config = models.get_model_config(model_name, model_args)
-    model = models.get_model(model_name, model_config, to_cuda=(not cpu_run),
+    model = models.get_model(model_name, model_config, cpu_run=cpu_run,
                              forward_is_infer=forward_is_infer)
 
     if checkpoint is not None:


### PR DESCRIPTION
#491 

#496 

Same as the train.py, for inference.py, the 'get_model' function throws the invalid 'to_cuda' error. I have updated the argument.

Here is the info trace:

`Traceback (most recent call last):
  File "inference.py", line 273, in <module>
    main()
  File "inference.py", line 206, in main
    args.fp16, args.cpu, forward_is_infer=True)
  File "inference.py", line 113, in load_and_setup_model
    forward_is_infer=forward_is_infer)
TypeError: get_model() got an unexpected keyword argument 'to_cuda'`