### PR TITLE
Enable async_io for squad.

### DIFF
--- a/TensorFlow/LanguageModeling/BERT/run_squad.py
+++ b/TensorFlow/LanguageModeling/BERT/run_squad.py
@@ -936,12 +936,12 @@ dynamic_batching {{
 def main(_):
   # causes memory fragmentation for bert leading to OOM
   if os.environ.get("TF_XLA_FLAGS", None) is not None:
-    os.environ["TF_XLA_FLAGS"] += "--tf_xla_enable_lazy_compilation=false"
+    os.environ["TF_XLA_FLAGS"] += " --tf_xla_enable_lazy_compilation=false"
   else:
     os.environ["TF_XLA_FLAGS"] = "--tf_xla_enable_lazy_compilation=false"
 
   # Enable async_io to speed up multi-gpu training with XLA and Horovod.
-  os.environ["TF_XLA_FLAGS"] += "--tf_xla_async_io_level=1"
+  os.environ["TF_XLA_FLAGS"] += " --tf_xla_async_io_level=1"
 
   tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
   dllogging = utils.dllogger_class.dllogger_class(FLAGS.dllog_path)

--- a/TensorFlow/LanguageModeling/BERT/run_squad.py
+++ b/TensorFlow/LanguageModeling/BERT/run_squad.py
@@ -940,6 +940,9 @@ def main(_):
   else:
     os.environ["TF_XLA_FLAGS"] = "--tf_xla_enable_lazy_compilation=false"
 
+  # Enable async_io to speed up multi-gpu training with XLA and Horovod.
+  os.environ["TF_XLA_FLAGS"] += "--tf_xla_async_io_level=1"
+
   tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
   dllogging = utils.dllogger_class.dllogger_class(FLAGS.dllog_path)
 


### PR DESCRIPTION

This reduces Horovod overhead when XLA is enabled.

~7-9% speedup is observed for BERT Squad fp32 and ~3-4% speedup for fp16.