### PR TITLE
Add info about NCCL issue in 2.7.5 (20.06)

### DIFF
--- a/TensorFlow2/Segmentation/UNet_Medical/README.md
+++ b/TensorFlow2/Segmentation/UNet_Medical/README.md
@@ -628,5 +628,6 @@ February 2020
  
 ### Known issues
  
+* Some set-ups suffer from a `ncclCommInitRank failed: unhandled system error`. This is a known issue with NCCL 2.7.5. The issue is solved in NCCL 2.7.8, which can be applied by changing the first line the Dockerfile from `ARG FROM_IMAGE_NAME=nvcr.io/nvidia/tensorflow:20.06-tf2-py3` to `ARG FROM_IMAGE_NAME=nvcr.io/nvidia/tensorflow:20.08-tf2-py3` and rebuilding the docker image.
 * For TensorFlow 2.0 the training performance using AMP and XLA is around 30% lower than reported here. The issue was solved in TensorFlow 2.1.
 


### PR DESCRIPTION
Adds info how to fix bugs such as https://github.com/NVIDIA/DeepLearningExamples/issues/679

```[1,0]<stderr>:Traceback (most recent call last):
[1,0]<stderr>:  File "main.py", line 69, in <module>
[1,0]<stderr>:    main()
[1,0]<stderr>:  File "main.py", line 57, in main
[1,0]<stderr>:    train(params, model, dataset, logger)
[1,0]<stderr>:  File "/workspace/unet/run.py", line 86, in train
[1,0]<stderr>:    train_step(images, labels, warmup_batch=iteration == 0)
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/def_function.py", line 580, in __call__
[1,0]<stderr>:    result = self._call(*args, **kwds)
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/def_function.py", line 644, in _call
[1,0]<stderr>:    return self._stateless_fn(*args, **kwds)
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 2420, in __call__
[1,0]<stderr>:    return graph_function._filtered_call(args, kwargs)  # pylint: disable=protected-access
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 1665, in _filtered_call
[1,0]<stderr>:    self.captured_inputs)
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 1746, in _call_flat
[1,0]<stderr>:    ctx, args, cancellation_manager=cancellation_manager))
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 598, in call
[1,0]<stderr>:    ctx=ctx)
[1,0]<stderr>:  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/execute.py", line 60, in quick_execute
[1,0]<stderr>:    inputs, attrs, num_outputs)
[1,0]<stderr>:tensorflow.python.framework.errors_impl.UnknownError:  ncclCommInitRank failed: unhandled system error
[1,0]<stderr>:	 [[node HorovodBroadcast_Adam_unet_output_block_conv2d_6_bias_m_0 (defined at <string>:234) ]] [Op:__inference_train_step_4208]
```

It is related to a known issue in NCCL 2.7.5 which is installed in the 20.06 container. Updating the container to 20.08 (NCCL 2.7.8) solves the issue.