### PR TITLE
[ConvNets/PyT] Fixed distributed checkpoint loading

### DIFF
--- a/PyTorch/Classification/ConvNets/classify.py
+++ b/PyTorch/Classification/ConvNets/classify.py
@@ -63,12 +63,16 @@ def main(args):
 
     if args.weights is not None:
         weights = torch.load(args.weights)
+
+        #Temporary fix to allow NGC checkpoint loading
+        weights = {k.replace("module.", ""): v for k, v in weights.items()}
+
         model.load_state_dict(weights)
 
     model = model.cuda()
 
     if args.precision in ["AMP", "FP16"]:
-        model = network_to_half(model)
+        model = model.half()
 
 
     model.eval()

--- a/PyTorch/Classification/ConvNets/main.py
+++ b/PyTorch/Classification/ConvNets/main.py
@@ -363,6 +363,10 @@ def main(args):
                 )
             )
             pretrained_weights = torch.load(args.pretrained_weights)
+
+            #Temporary fix to allow NGC checkpoint loading
+
+            pretrained_weights = {k.replace("module.", ""): v for k, v in pretrained_weights.items()}
         else:
             print("=> no pretrained weights found at '{}'".format(args.resume))
 


### PR DESCRIPTION
Pytorch DDP model checkpoints contain "model." prefix.
This makes keys to mismatch during loading the checkpoint.

This fix removes the prefix if exists during load, allowing to use NGC checkpoints.