### PR TITLE
Fixed NVIDIA torchhub non-working model URLs

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -136,9 +136,9 @@ def nvidia_tacotron2(pretrained=True, **kwargs):
 
     if pretrained:
         if fp16:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2pyt_fp16/versions/1/files/nvidia_tacotron2pyt_fp16_20190306.pth'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_pyt_ckpt_amp/versions/19.09.0/files/nvidia_tacotron2pyt_fp16_20190427'
         else:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2pyt_fp32/versions/1/files/nvidia_tacotron2pyt_fp32_20190306.pth'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_pyt_ckpt_fp32/versions/19.09.0/files/nvidia_tacotron2pyt_fp32_20190427'
         ckpt_file = _download_checkpoint(checkpoint, force_reload)
         ckpt = torch.load(ckpt_file)
         state_dict = ckpt['state_dict']
@@ -193,9 +193,9 @@ def nvidia_waveglow(pretrained=True, **kwargs):
 
     if pretrained:
         if fp16:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/waveglowpyt_fp16/versions/1/files/nvidia_waveglowpyt_fp16_20190306.pth'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/waveglow_ckpt_amp/versions/19.09.0/files/nvidia_waveglowpyt_fp16_20190427'
         else:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/waveglowpyt_fp32/versions/1/files/nvidia_waveglowpyt_fp32_20190306.pth'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/waveglow_ckpt_fp32/versions/19.09.0/files/nvidia_waveglowpyt_fp32_20190427'
         ckpt_file = _download_checkpoint(checkpoint, force_reload)
         ckpt = torch.load(ckpt_file)
         state_dict = ckpt['state_dict']
@@ -364,9 +364,9 @@ def nvidia_ssd(pretrained=True, **kwargs):
 
     if pretrained:
         if fp16:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/ssdpyt_fp16/versions/1/files/nvidia_ssdpyt_fp16_20190225.pt'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/ssd_pyt_ckpt_amp/versions/19.09.0/files/nvidia_ssdpyt_fp16_190826.pt'
         else:
-            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/ssdpyt_fp32/versions/1/files/nvidia_ssdpyt_fp32_20190225.pt'
+            checkpoint = 'https://api.ngc.nvidia.com/v2/models/nvidia/ssdpyt_fp32/versions/1/files/nvidia_ssdpyt_fp32_20190225.pt' # Not available
         # ckpt = torch.hub.load_state_dict_from_url(checkpoint, progress=True, check_hash=False)
         ckpt_file = _download_checkpoint(checkpoint, force_reload)
         ckpt = torch.load(ckpt_file)


### PR DESCRIPTION
This PR fixes the NVIDIA models' non-working URLs, as those models could not be imported from `torch.hub.load` as stated in #725 and #721 among some other issues. So on, in order to get it working, after an exhaustive search on [NVIDIA Catalog Models]() the valid (working) URLs have been found as the previous ones where throwing a 404 HTTP error while trying to be downloaded.

This issue has been reported in pytorch#761 and the issues found in this repository have been spotted by @harshbafna, so once the model URLs were fixed and proved that they worked, the PR has been created in this repository so as to fix it for all the PyTorch users trying to download these models.

Updated model URLs:
- [Tacotron2 FP16](https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_pyt_ckpt_amp/versions/19.09.0/files/nvidia_tacotron2pyt_fp16_20190427)
- [Tacotron2 FP32](https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_pyt_ckpt_fp32/versions/19.09.0/files/nvidia_tacotron2pyt_fp32_20190427)
- [Waveglow FP16](https://api.ngc.nvidia.com/v2/models/nvidia/waveglow_ckpt_amp/versions/19.09.0/files/nvidia_waveglowpyt_fp16_20190427)
- [Waveglow FP32](https://api.ngc.nvidia.com/v2/models/nvidia/waveglow_ckpt_fp32/versions/19.09.0/files/nvidia_waveglowpyt_fp32_20190427)
- [SSD FP16](https://api.ngc.nvidia.com/v2/models/nvidia/ssd_pyt_ckpt_amp/versions/19.09.0/files/nvidia_ssdpyt_fp16_190826.pt)

Now once this gets merged the following operations from PyTorch would work again as usual:

```python
import torch

model = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_tacotron2', model_math='fp16')
model = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_tacotron2', model_math='fp32')
model = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_waveglow', model_math='fp16')
model = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_waveglow', model_math='fp32')
model = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_ssd', model_math='fp16')
```

Anyway, the URL for the model SSD with FP16 Precision couldn't be found on the Catalog, so it may need another update. Please let me know which is the updated URL.

__P.S. As a workaround until this gets merged you can load them using the following piece of code:__

```python
import torch

model = torch.hub.load('alvarobartt/DeepLearningExamples:nvidia-urls-fix', 'nvidia_tacotron2', model_math='fp16')
model = torch.hub.load('alvarobartt/DeepLearningExamples:nvidia-urls-fix', 'nvidia_tacotron2', model_math='fp32')
model = torch.hub.load('alvarobartt/DeepLearningExamples:nvidia-urls-fix', 'nvidia_waveglow', model_math='fp16')
model = torch.hub.load('alvarobartt/DeepLearningExamples:nvidia-urls-fix', 'nvidia_waveglow', model_math='fp32')
model = torch.hub.load('alvarobartt/DeepLearningExamples:nvidia-urls-fix', 'nvidia_ssd', model_math='fp16')
```