### PR TITLE
Accommodate batch size of 1

### DIFF
--- a/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py
+++ b/PyTorch/SpeechSynthesis/Tacotron2/tacotron2/model.py
@@ -501,7 +501,7 @@ class Decoder(nn.Module):
                                               mask)
 
             mel_outputs += [mel_output.squeeze(1)]
-            gate_outputs += [gate_output.squeeze()]
+            gate_outputs += [gate_output.squeeze(1)]
             alignments += [attention_weights]
 
         mel_outputs, gate_outputs, alignments = self.parse_decoder_outputs(


### PR DESCRIPTION
When batch size is 1, `squeeze` collapses the batch dimension. Explicitly pass dimension to avoid this behavior.