### PR TITLE
Fixing the docker file in pytorch maskr cnn

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/docker/Dockerfile
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y \
  && apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev
 
 # Install Miniconda
-RUN curl -so /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -Lso /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x /miniconda.sh \
  && /miniconda.sh -b -p /miniconda \
  && rm /miniconda.sh

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/docker/docker-jupyter/Dockerfile
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/docker/docker-jupyter/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y \
  && apt-get install -y apt-utils git curl ca-certificates bzip2 cmake tree htop bmon iotop g++
 
 # Install Miniconda
-RUN curl -so /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -Lso /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x /miniconda.sh \
  && /miniconda.sh -b -p /miniconda \
  && rm /miniconda.sh


### PR DESCRIPTION
Currently the build of the docker file fails because of a 301 on curl miniconda install. This is a quick fix