### PR TITLE
[PyTorch/Classification] Added memory_padding to ValPipe

### DIFF
--- a/PyTorch/Classification/ConvNets/image_classification/dataloaders.py
+++ b/PyTorch/Classification/ConvNets/image_classification/dataloaders.py
@@ -162,7 +162,13 @@ class HybridValPipe(Pipeline):
             random_shuffle=False,
         )
 
-        self.decode = ops.ImageDecoder(device="mixed", output_type=types.RGB)
+        self.decode = ops.ImageDecoder(
+            device="mixed", 
+            output_type=types.RGB,
+            device_memory_padding=117440512,
+            host_memory_padding=8388608,
+        )
+        
         self.res = ops.Resize(device="gpu", resize_shorter=size)
         self.cmnp = ops.CropMirrorNormalize(
             device="gpu",


### PR DESCRIPTION
Training ResNet50 on ImageNet sometimes crashes during the validation phase when I am using the recommended V100 + AMP batch size of 256. The error message indicates memory allocation problems so I ran the DALI `ImageDecoder` within the ValPipe with `memory=stats=True` and added the reported numbers as device and host memory padding.
 
```
RuntimeError: Critical error in pipeline:
Error when executing Mixed operator ImageDecoder encountered:
Error in thread 1: [/opt/dali/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h:809] NVJPEG error "5" : NVJPEG_STATUS_ALLOCATOR_FAILURE n02130308/ILSVRC2012_val_00033687.JPEG
Stacktrace (7 entries):
[frame 0]: /home/lbhm/venv/lib/python3.8/site-packages/nvidia/dali/libdali_operators.so(+0x401dee) [0x7f7594e77dee]
[frame 1]: /home/lbhm/venv/lib/python3.8/site-packages/nvidia/dali/libdali_operators.so(+0x7ad134) [0x7f7595223134]
[frame 2]: /home/lbhm/venv/lib/python3.8/site-packages/nvidia/dali/libdali_operators.so(+0x7adb04) [0x7f7595223b04]
[frame 3]: /home/lbhm/venv/lib/python3.8/site-packages/nvidia/dali/libdali.so(dali::ThreadPool::ThreadMain(int, int, bool)+0x217) [0x7f7593cca647]
[frame 4]: /home/lbhm/venv/lib/python3.8/site-packages/nvidia/dali/libdali.so(+0x8a6b5f) [0x7f7594414b5f]
[frame 5]: /lib/x86_64-linux-gnu/libpthread.so.0(+0x76ba) [0x7f77605696ba]
[frame 6]: /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f775f74c4dd]
```