### PR TITLE
Update URLs for GLUE downloader.

### DIFF
--- a/FasterTransformer/v3.1/bert-quantization/bert-pyt-quantization/data/GLUEDownloader.py
+++ b/FasterTransformer/v3.1/bert-quantization/bert-pyt-quantization/data/GLUEDownloader.py
@@ -36,7 +36,7 @@ class GLUEDownloader:
             assert task_name == 'sst-2'
             task_name = 'SST'
         wget.download(
-            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/17b8dd0d724281ed7c3b2aeeda662b92809aadd5/download_glue_data.py',
+            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/1502038877f6a88c225a34450793fbc3ea87eaba/download_glue_data.py',
             out=self.save_path,
         )
         sys.path.append(self.save_path)

--- a/PyTorch/LanguageModeling/BERT/data/GLUEDownloader.py
+++ b/PyTorch/LanguageModeling/BERT/data/GLUEDownloader.py
@@ -36,7 +36,7 @@ class GLUEDownloader:
             assert task_name == 'sst-2'
             task_name = 'SST'
         wget.download(
-            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/17b8dd0d724281ed7c3b2aeeda662b92809aadd5/download_glue_data.py',
+            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/1502038877f6a88c225a34450793fbc3ea87eaba/download_glue_data.py',
             out=self.save_path,
         )
         sys.path.append(self.save_path)

--- a/TensorFlow/LanguageModeling/BERT/data/GLUEDownloader.py
+++ b/TensorFlow/LanguageModeling/BERT/data/GLUEDownloader.py
@@ -36,7 +36,7 @@ class GLUEDownloader:
             assert task_name == 'sst-2'
             task_name = 'SST'
         wget.download(
-            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/17b8dd0d724281ed7c3b2aeeda662b92809aadd5/download_glue_data.py',
+            'https://gist.githubusercontent.com/W4ngatang/60c2bdb54d156a41194446737ce03e2e/raw/1502038877f6a88c225a34450793fbc3ea87eaba/download_glue_data.py',
             out=self.save_path,
         )
         sys.path.append(self.save_path)


### PR DESCRIPTION
This PR fixes an issue, #854. Current URL is older version URL for `download_glue_data.py`, but recently the URLs for dataset have been updated. Therefore, it needs to be updated.