### PR TITLE
[Jasper/PyT] Fix version of pyYAML==5.3.1 to prevent pip from crashing

### DIFF
--- a/PyTorch/SpeechRecognition/Jasper/requirements.txt
+++ b/PyTorch/SpeechRecognition/Jasper/requirements.txt
@@ -3,7 +3,7 @@ ipdb
 librosa==0.8.0
 pandas==1.1.4
 pycuda==2020.1
-pyyaml
+pyyaml==5.3.1
 soundfile
 sox==1.4.1
 tqdm==4.53.0


### PR DESCRIPTION
`pip` crashes upon `pyYAML` update attempt. Keep the stock version from the `20.10` container.