### PR TITLE
[FIX] Triton kaldi backend's Jupyter notebook Dockerfile "llvm" error…

### DIFF
--- a/Kaldi/SpeechRecognition/Dockerfile.notebook
+++ b/Kaldi/SpeechRecognition/Dockerfile.notebook
@@ -27,5 +27,6 @@ RUN apt-get update && apt-get install -y jupyter \
                    vim
 
 RUN python3 -m pip uninstall -y pip
-RUN apt install python3-pip --reinstall
+RUN apt install -y python3-pip --reinstall
+RUN pip3 install --upgrade pip
 RUN pip3 install matplotlib soundfile librosa sounddevice


### PR DESCRIPTION
`
    LLVM version... Traceback (most recent call last):
      File "/tmp/pip-build-fpzjctwx/llvmlite/ffi/build.py", line 220, in <module>
        main()
      File "/tmp/pip-build-fpzjctwx/llvmlite/ffi/build.py", line 210, in main
        main_posix('linux', '.so')
      File "/tmp/pip-build-fpzjctwx/llvmlite/ffi/build.py", line 134, in main_posix
        raise RuntimeError(msg) from None
    RuntimeError: Could not find a `llvm-config` binary. There are a number of reasons this could occur, please see: https://llvmlite.readthedocs.io/en/latest/admin-guide/install.html#using-pip for help.
    error: command '/usr/bin/python3' failed with exit status 1
    
    ----------------------------------------
Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-fpzjctwx/llvmlite/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-w6boa4qi-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-fpzjctwx/llvmlite/`

This error occurs because of old pip3 version (pip==9.0.1)

Also:
`RUN apt install **-y** python3-pip --reinstall` resolves:
`The command '/bin/sh -c apt install python3-pip --reinstall' returned a non-zero code: 1`