### PR TITLE
[BERT/PyT] Verify Wiki archive download success

### DIFF
--- a/PyTorch/LanguageModeling/BERT/README.md
+++ b/PyTorch/LanguageModeling/BERT/README.md
@@ -280,7 +280,7 @@ The pretraining dataset is 170GB+ and takes 15+ hours to download. The BookCorpu
 Users are welcome to download BookCorpus from other sources to match our accuracy, or repeatedly try our script until the required number of files are downloaded by running the following:
 `/workspace/bert/data/create_datasets_from_start.sh wiki_books`
 
-Note: Ensure a complete Wikipedia download. If in any case, the download breaks, remove the output file `wikicorpus_en.xml.bz2` and start again. If a partially downloaded file exists, the script assumes successful download which causes the extraction to fail. Not using BookCorpus can potentially change final accuracy on a few downstream tasks.
+Note: If the Wikipedia archive is already downloaded locally, the script will verify the local md5sum hash matches what is on the website. If not, the dataset will be re-downloaded automatically to ensure it is valid. Not using BookCorpus can potentially change final accuracy on a few downstream tasks.
 
 6. Start pretraining.
  

--- a/PyTorch/LanguageModeling/BERT/data/create_datasets_from_start.sh
+++ b/PyTorch/LanguageModeling/BERT/data/create_datasets_from_start.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Terminate the script if any commands fail
+set -e
+
 to_download=${1:-"wiki_only"}
 
 #Download


### PR DESCRIPTION
At present, the WikiDownloader for BERT/PyTorch expects that if the wikicorpus archive is in the local filesystem, then it was successfully downloaded without interrpution. If, however, the download was interrupted for any number of reasons and the WikiDownloader is run again, it will assume the archive is valid and attempt to extract or pre-process a corrupt dataset. Since it appears the dataset is valid in the local filesystem, these errors that are encountered later on are very hard to debug as they don't indicate the error exists with the downloaded archive.

By pulling the latest checksums file from the WikiMedia repository, the local archive if present can be compared against the expected checksum. If the local archive's hash and the expected checksum match, then it is safe to assume the dataset is valid and extraction can continue.

Additionally, the `create_datasets_from_start.sh` script should terminate if any of the included commands fail as a failed command likely means something is wrong with the setup or connections and it needs to be investigated before continuing with later steps that would likely fail silently as well.

Signed-Off-By: Robert Clark <roclark@nvidia.com>