### PR TITLE
[BERT/PyT] Force re-extraction of Wiki dataset

### DIFF
--- a/PyTorch/LanguageModeling/BERT/data/WikiDownloader.py
+++ b/PyTorch/LanguageModeling/BERT/data/WikiDownloader.py
@@ -55,7 +55,7 @@ class WikiDownloader:
 
             # Always unzipping since this is relatively fast and will overwrite
             print('Unzipping:', self.output_files[self.language])
-            subprocess.run('bzip2 -dk ' + self.save_path + '/' + filename, shell=True, check=True)
+            subprocess.run('bzip2 -dkf ' + self.save_path + '/' + filename, shell=True, check=True)
 
         else:
             assert False, 'WikiDownloader not implemented for this language yet.'


### PR DESCRIPTION
If either a partial or fully extracted Wiki dataset is found in the WikiDownloader while attempting to re-extract, an error will be thrown that the output file already exists. By adding the `-f` flag to the `bzip2` command, the dataset will be extracted automatically, overwriting any existing output files.

Signed-Off-By: Robert Clark <roclark@nvidia.com>