### PR TITLE
Fix issue with Docker build for Tensorflow's SSD

### DIFF
--- a/TensorFlow/Detection/SSD/Dockerfile
+++ b/TensorFlow/Detection/SSD/Dockerfile
@@ -29,5 +29,4 @@ ENV PYTHONPATH="/workdir/models/research/:/workdir/models/research/slim/:$PYTHON
 
 COPY examples/ examples
 COPY configs/ configs/
-COPY qa/ qa/
 COPY download_all.sh download_all.sh


### PR DESCRIPTION
The `qa` directory is absent from the `/DeepLearningExamples/TensorFlow/Detection/SSD`
and this results in build failure:

`COPY failed: file not found in build context or excluded by .dockerignore: stat qa/: file does not exist`

The error is solved after removing the corresponding line from the Dockerfile.