### PR TITLE
[Jasper/PyT] Add dllogger to requirements

### DIFF
--- a/PyTorch/SpeechRecognition/Jasper/requirements.txt
+++ b/PyTorch/SpeechRecognition/Jasper/requirements.txt
@@ -8,3 +8,4 @@ soundfile
 sox==1.4.1
 tqdm==4.53.0
 wrapt==1.10.11
+git+git://github.com/NVIDIA/dllogger.git@26a0f8f1958de2c0c460925ff6102a4d2486d6cc#egg=dllogger


### PR DESCRIPTION
Upcoming NGC containers will no longer come with `dllogger` pre-installed.