### PR TITLE
Set GPU index based on local_rank instead of rank

### DIFF
--- a/TensorFlow/Recommendation/NCF/ncf.py
+++ b/TensorFlow/Recommendation/NCF/ncf.py
@@ -227,7 +227,7 @@ def main():
     # Create and run Data Generator in a separate thread
     data_generator = DataGenerator(
         args.seed,
-        hvd.rank(),
+        hvd.local_rank(),
         nb_users,
         nb_items,
         neg_mat,


### PR DESCRIPTION
# Problem
Passing `hvd.rank()` into `DataGenerator`
https://github.com/NVIDIA/DeepLearningExamples/blob/ef98b2cef9dfdd3cf61f028bc5b33e7db48d49ec/TensorFlow/Recommendation/NCF/ncf.py#L230
```
    # Create and run Data Generator in a separate thread
    data_generator = DataGenerator(
        args.seed,
        hvd.rank(),
        nb_users,
        ...
```



will cause `cp.cuda.Device(self.hvd_rank).use()`
https://github.com/NVIDIA/DeepLearningExamples/blob/ef98b2cef9dfdd3cf61f028bc5b33e7db48d49ec/TensorFlow/Recommendation/NCF/input_pipeline.py#L91
```
        # Use GPU assigned to the horovod rank
        self.hvd_rank = hvd_rank
        cp.cuda.Device(self.hvd_rank).use()
```
set the wrong GPU index when using multiple nodes, leading to
```
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorInvalidDevice: invalid device ordinal
```
# Solution
replace `hvd.rank()` with `hvd.local_rank()`