### PR TITLE
[SSD/PyT] Switching data from nchw to nhwc format

### DIFF
--- a/PyTorch/Detection/SSD/src/model.py
+++ b/PyTorch/Detection/SSD/src/model.py
@@ -108,7 +108,7 @@ class SSD300(nn.Module):
     def bbox_view(self, src, loc, conf):
         ret = []
         for s, l, c in zip(src, loc, conf):
-            ret.append((l(s).view(s.size(0), 4, -1), c(s).view(s.size(0), self.label_num, -1)))
+            ret.append((l(s).reshape(s.size(0), 4, -1), c(s).reshape(s.size(0), self.label_num, -1)))
 
         locs, confs = list(zip(*ret))
         locs, confs = torch.cat(locs, 2).contiguous(), torch.cat(confs, 2).contiguous()

--- a/PyTorch/Detection/SSD/src/train.py
+++ b/PyTorch/Detection/SSD/src/train.py
@@ -46,6 +46,7 @@ def train_loop(model, loss_func, epoch, optim, train_dataloader, val_dataloader,
         bbox = bbox.view(N, M, 4)
         label = label.view(N, M)
 
+        img = img.to(memory_format=torch.channels_last)
         ploc, plabel = model(img)
         ploc, plabel = ploc.float(), plabel.float()
 
@@ -116,7 +117,7 @@ def benchmark_train_loop(model, loss_func, epoch, optim, train_dataloader, val_d
 
 
 
-
+        img = img.to(memory_format=torch.channels_last)
         ploc, plabel = model(img)
         ploc, plabel = ploc.float(), plabel.float()
 


### PR DESCRIPTION
Upon profiling the PyTorch Detection/SSD code with resnet50, we noticed a lot of NCHW-NHWC transpose kernels. The changes suggested in this pull request will switch the input data format from NCHW to NHWC to comply with the more efficient memory format on Tensor Cores, and we have observed a ~50% throughput improvement on an A100 80G card.

python ./main.py --backbone resnet50 --warmup 300 --bs 256 --amp --data <coco2017 data> --epochs 1 --mode benchmark-training --benchmark-iterations 100 --num-workers 1

Before: Total images: 25600  total time: 60.946      Average images/sec: 420.047     Median images/sec: 420.351
After: Total images: 25600  total time: 40.827      Average images/sec: 627.030     Median images/sec: 627.356

