### PR TITLE
Fix a logic flaw that causes checkpoints to be saved at wrong epochs in the transformer example.

### DIFF
--- a/PyTorch/Translation/Transformer/train.py
+++ b/PyTorch/Translation/Transformer/train.py
@@ -364,7 +364,7 @@ def _all_gather_predictions(predictions):
 
 
 def save_checkpoint(args, trainer, epoch_itr, val_loss):
-    if epoch_itr.epoch % args.save_interval == 0:
+    if epoch_itr.epoch % args.save_interval != 0:
         return
     if args.no_save or not distributed_utils.is_master(args):
         return


### PR DESCRIPTION
Currently, `save_checkpoint`function decides whether the current epoch has reached the interval of saving checkpoints by:
```def save_checkpoint(args, trainer, epoch_itr, val_loss):
    if epoch_itr.epoch % args.save_interval == 0:
        return  # won't save anything
    ... # process & save
```
However, instead of skiping the saving process when `epoch_itr.epoch % args.save_interval == 0`, it should actually save the model here. In the worst case and the default case (`args.save_interval = 1`), the program won't save any checkpoints at all.