### PR TITLE
Fixed an incorrect numerical comparison in numbers.py

### DIFF
--- a/PyTorch/SpeechSynthesis/FastPitch/common/text/numerical.py
+++ b/PyTorch/SpeechSynthesis/FastPitch/common/text/numerical.py
@@ -112,7 +112,7 @@ def _expand_roman(m):
 def _expand_number(m):
     _, number, suffix = re.split(r"(\d+(?:'?\d+)?)", m.group(0))
     number = int(number)
-    if number > 1000 < 10000 and (number % 100 == 0) and (number % 1000 != 0):
+    if 1000 < number < 10000 and (number % 100 == 0) and (number % 1000 != 0):
         text = _inflect.number_to_words(number // 100) + " hundred"
     elif number > 1000 and number < 3000:
         if number == 2000:


### PR DESCRIPTION
# Issue
The original statement (at line 115 of [numbers.py](PyTorch/SpeechSynthesis/FastPitch/common/text/numerical.py)) of:
```python
if number > 1000 < 10000 and (number % 100 == 0) and (number % 1000 != 0):
```
is an invalid numerical comparison which translates to `(number > 1000) and (1000 < 10000)`. In effect only `number > 1000`
is evaluated, as `1000 < 10000` is always True.

## Affected Public Methods
The primary public method of the file, `normalize_numbers()` currently returns an incorrect conversion for numbers that are greater than 10,000 which also satify the conditions `(number % 100 == 0)` and `(number % 1000 != 0)`.

```python
normalize_numbers('15,500')
>>> 'one hundred and fifty-five hundred'
```

# Proposed fix
The proposed fix is to use the correct mathematical form of the comparison as documented in https://docs.python.org/3/reference/expressions.html#comparisons
```python
if 1000 < number < 10000 and (number % 100 == 0) and (number % 1000 != 0):
```

This results in the correct conversion of numbers greater than 10000, divisible by 100, and indivisible by 1000:
```python
normalize_numbers('15,500')
>>> 'fifteen thousand five hundred'
```