### PR TITLE
Remove tf.data.experimental.MapVectorizationOptions api to avoid AttributeError

### DIFF
--- a/TensorFlow2/Segmentation/MaskRCNN/mrcnn_tf2/dataset/dataset.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mrcnn_tf2/dataset/dataset.py
@@ -128,9 +128,5 @@ class Dataset:
         data_options.experimental_threading.max_intra_op_parallelism = 1
         data_options.experimental_optimization.map_parallelization = True
 
-        map_vectorization_options = tf.data.experimental.MapVectorizationOptions()
-        map_vectorization_options.enabled = True
-        map_vectorization_options.use_choose_fastest = True
-        data_options.experimental_optimization.map_vectorization = map_vectorization_options
 
         return data_options


### PR DESCRIPTION
The current MaskRCNN train.py has the AttributeError.
    `File "/opt/DeepLearningExamples/TensorFlow2/Segmentation/MaskRCNN/mrcnn_tf2/dataset/dataset.py", line 131, in _data_options
        map_vectorization_options = tf.data.experimental.MapVectorizationOptions()
    AttributeError: module 'tensorflow._api.v2.data.experimental' has no attribute 'MapVectorizationOptions'`

In the release [notes](https://releases.linaro.org/components/ldcg/tensorflow-cpu/r2.6.0-rc1/) of tf 2.6, it mentions that `tf.data.experimental.MapVectorizationOptions.*` is removed. The removal of this options does not impact the performance.