### PR TITLE
Fix len() for lddl dataloader

### DIFF
--- a/Tools/lddl/lddl/torch/dataloader.py
+++ b/Tools/lddl/lddl/torch/dataloader.py
@@ -78,4 +78,4 @@ class DataLoader(torch.utils.data.DataLoader):
           (num_samples_per_worker - 1) // self.batch_size + 1)
       return num_batches_per_worker * num_workers_per_rank
     else:
-      super().__len__()
+      return super().__len__()


### PR DESCRIPTION
When using dataloader to load my own dataset, I found there was no return in len() for non-ParquetDataset. I guess it's a bug.