### PR TITLE
change batch_and_drop_remainder to batch(batch_size, drop_remainder)

### DIFF
--- a/TensorFlow/Detection/SSD/models/research/object_detection/builders/dataset_builder.py
+++ b/TensorFlow/Detection/SSD/models/research/object_detection/builders/dataset_builder.py
@@ -162,8 +162,7 @@ def build(input_reader_config, batch_size=None, transform_input_data_fn=None, mu
         process_fn,
         num_parallel_calls=num_parallel_calls)
     if batch_size:
-      dataset = dataset.apply(
-          tf.contrib.data.batch_and_drop_remainder(batch_size))
+      dataset = dataset.batch(batch_size, drop_remainder=True)
     dataset = dataset.prefetch(input_reader_config.num_prefetch_batches)
     return dataset
 


### PR DESCRIPTION
According to the Tensorflow documentation, batch_and_drop_remainder is deprecated. Instead should use batch(batch_size, drop_remainder=True).