### PR TITLE
Unused parameters in ConvAttention

### DIFF
--- a/PyTorch/SpeechSynthesis/FastPitch/fastpitch/attention.py
+++ b/PyTorch/SpeechSynthesis/FastPitch/fastpitch/attention.py
@@ -90,7 +90,6 @@ class ConvAttention(torch.nn.Module):
         self.softmax = torch.nn.Softmax(dim=3)
         self.log_softmax = torch.nn.LogSoftmax(dim=3)
         self.query_proj = Invertible1x1ConvLUS(n_mel_channels)
-        self.attn_proj = torch.nn.Conv2d(n_att_channels, 1, kernel_size=1)
         self.align_query_enc_type = align_query_enc_type
         self.use_query_proj = bool(use_query_proj)
 

--- a/PyTorch/SpeechSynthesis/HiFiGAN/fastpitch/attention.py
+++ b/PyTorch/SpeechSynthesis/HiFiGAN/fastpitch/attention.py
@@ -90,7 +90,6 @@ class ConvAttention(torch.nn.Module):
         self.softmax = torch.nn.Softmax(dim=3)
         self.log_softmax = torch.nn.LogSoftmax(dim=3)
         self.query_proj = Invertible1x1ConvLUS(n_mel_channels)
-        self.attn_proj = torch.nn.Conv2d(n_att_channels, 1, kernel_size=1)
         self.align_query_enc_type = align_query_enc_type
         self.use_query_proj = bool(use_query_proj)
 


### PR DESCRIPTION
Hi Nvidia team,

It appears that the ConvAttention module has learnable parameters that are not used in computing the loss tensor.
Should they be removed from the constructor?

There are two unused constants as well, `self.temperature` and `self.att_scaling_factor`.