### PR TITLE
fix(sec): upgrade networkx to 2.6

### DIFF
--- a/PyTorch/Classification/ConvNets/triton/requirements.txt
+++ b/PyTorch/Classification/ConvNets/triton/requirements.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-networkx==2.5
+networkx==2.6
 onnx==1.8.0
 onnxruntime==1.5.2
 pycuda>=2019.1.2

--- a/PyTorch/Classification/GPUNet/triton/requirements.txt
+++ b/PyTorch/Classification/GPUNet/triton/requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.5#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 pycuda>=2019.1.2
 PyYAML>=5.2
 tabulate>=0.8.7

--- a/PyTorch/Forecasting/TFT/triton/requirements.txt
+++ b/PyTorch/Forecasting/TFT/triton/requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.5#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 numpy
 onnx>=1.8.0,<1.9.0
 onnxruntime-gpu==1.8.1

--- a/PyTorch/LanguageModeling/BERT/triton/requirements.txt
+++ b/PyTorch/LanguageModeling/BERT/triton/requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.3#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 numpy
 onnx==1.8.1
 onnxruntime-gpu==1.8.1

--- a/PyTorch/Segmentation/nnUNet/triton/requirements.txt
+++ b/PyTorch/Segmentation/nnUNet/triton/requirements.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-networkx==2.5
+networkx==2.6
 onnx==1.8.0
 onnxruntime==1.5.2
 pycuda>=2019.1.2

--- a/PyTorch/SpeechSynthesis/FastPitch/triton/requirements.txt
+++ b/PyTorch/SpeechSynthesis/FastPitch/triton/requirements.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-networkx==2.5
+networkx==2.6
 numpy
 onnx==1.8.0
 onnxruntime==1.5.2

--- a/TensorFlow/Classification/ConvNets/triton/requirements.txt
+++ b/TensorFlow/Classification/ConvNets/triton/requirements.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-networkx==2.5
+networkx==2.6
 onnx>=1.8.0
 onnxruntime>=1.9.0
 pycuda>=2019.1.2

--- a/TensorFlow2/Recommendation/WideAndDeep/triton/requirements.txt
+++ b/TensorFlow2/Recommendation/WideAndDeep/triton/requirements.txt
@@ -14,7 +14,7 @@
 
 model_navigator[tf] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.5#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 numpy
 onnx>=1.8.0,<1.9.0
 onnxruntime-gpu==1.8.1

--- a/Tools/PyTorch/TimeSeriesPredictionPlatform/models/tft_pyt/triton/requirements.txt
+++ b/Tools/PyTorch/TimeSeriesPredictionPlatform/models/tft_pyt/triton/requirements.txt
@@ -14,7 +14,7 @@
 # model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.3#egg=model_navigator
 model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.5#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 numpy
 onnx>=1.8.0,<1.9.0
 onnxruntime-gpu==1.8.1

--- a/Tools/PyTorch/TimeSeriesPredictionPlatform/triton/requirements.txt
+++ b/Tools/PyTorch/TimeSeriesPredictionPlatform/triton/requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 model_navigator[pyt] @ git+https://github.com/triton-inference-server/model_navigator.git@v0.2.7#egg=model_navigator
 natsort>=7.0.0
-networkx==2.5
+networkx==2.6
 numpy
 onnx>=1.8.0,<1.9.0
 onnxruntime-gpu==1.8.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in networkx 2.5
- [MPS-2022-15000](https://www.oscs1024.com/hd/MPS-2022-15000)


### What did I do？
Upgrade networkx from 2.5 to 2.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS