### PR TITLE
fix(sec): upgrade scikit-learn to 0.24.2

### DIFF
--- a/TensorFlow2/Segmentation/nnUNet/requirements.txt
+++ b/TensorFlow2/Segmentation/nnUNet/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/NVIDIA/dllogger
 git+https://github.com/NVIDIA/mlperf-common.git
 nibabel==3.1.1
 joblib==0.16.0
-scikit-learn==0.23.2
+scikit-learn==0.24.2
 pynvml==8.0.4
 fsspec==0.8.0
 scikit-image==0.18.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scikit-learn 0.23.2
- [MPS-2022-15126](https://www.oscs1024.com/hd/MPS-2022-15126)


### What did I do？
Upgrade scikit-learn from 0.23.2 to 0.24.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS