### PR TITLE
replace_static.sparsity_with_incubate.asp

### DIFF
--- a/PaddlePaddle/Classification/RN50v1.5/program.py
+++ b/PaddlePaddle/Classification/RN50v1.5/program.py
@@ -30,7 +30,7 @@ import paddle
 import paddle.nn.functional as F
 from paddle.distributed import fleet
 from paddle.distributed.fleet import DistributedStrategy
-from paddle.static import sparsity
+from paddle.incubate import asp
 from paddle.distributed.fleet.meta_optimizers.common import CollectiveHelper
 
 
@@ -228,7 +228,7 @@ def build(args, main_prog, startup_prog, step_each_epoch, is_train=True):
                 out, feeds, class_num, args.label_smoothing, mode=mode)
 
             if args.asp:
-                sparsity.set_excluded_layers(main_prog, [model.fc.weight.name])
+                asp.set_excluded_layers(main_prog, [model.fc.weight.name])
 
             lr_scheduler = None
             optimizer = None


### PR DESCRIPTION
### What happened？
paddle.static.sparsity has been removed and is now replaced by paddle.incubate.asp.
see pr for details.
https://github.com/PaddlePaddle/Paddle/pull/48450

### What did I do？
replace paddle.static.sparsity with paddle.incubate.asp

### What did you expect to happen？
eliminate the impact of removing paddle.static.sparsity

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS