### PR TITLE
fix(sec): upgrade ujson to 5.4.0

### DIFF
--- a/PyTorch/Detection/SSD/requirements.txt
+++ b/PyTorch/Detection/SSD/requirements.txt
@@ -1,3 +1,3 @@
 Cython>=0.28.4
 scikit-image>=0.15.0
-ujson>=4.0.2
+ujson>=5.4.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ujson 4.0.2
- [CVE-2022-31116](https://www.oscs1024.com/hd/CVE-2022-31116)


### What did I do？
Upgrade ujson from 4.0.2 to 5.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS