### PR TITLE
fix(sec): upgrade wandb to 0.12.12

### DIFF
--- a/DGLPyTorch/DrugDiscovery/SE3Transformer/requirements.txt
+++ b/DGLPyTorch/DrugDiscovery/SE3Transformer/requirements.txt
@@ -1,4 +1,4 @@
 e3nn==0.3.3
-wandb==0.12.0
+wandb==0.12.12
 pynvml==11.0.0
 git+https://github.com/NVIDIA/dllogger#egg=dllogger


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in wandb 0.12.0
- [MPS-2022-54910](https://www.oscs1024.com/hd/MPS-2022-54910)


### What did I do？
Upgrade wandb from 0.12.0 to 0.12.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS