### PR TITLE
fix: default value of '--gather-checkpoints' should be int type not str

### DIFF
--- a/PyTorch/Classification/ConvNets/main.py
+++ b/PyTorch/Classification/ConvNets/main.py
@@ -280,7 +280,7 @@ def add_parser_arguments(parser, skip_arch=False):
 
     parser.add_argument(
         "--gather-checkpoints",
-        default="0",
+        default=0,
         type=int,
         help=(
             "Gather N last checkpoints throughout the training,"


### PR DESCRIPTION
In the current code, the default value of '--gather-checkpoints' is '0' which is a string type, and this default value will cause all checkpoints to be saved. 

https://github.com/NVIDIA/DeepLearningExamples/blob/6610c05c330b887744993fca30532cbb9561cbde/PyTorch/Classification/ConvNets/main.py#L281-L284

The default value should be interger 0.
``` 
parser.add_argument( 
     "--gather-checkpoints", 
     default=0, 
     type=int, 
```