### PR TITLE
fix(sec): upgrade onnx to 1.13.0

### DIFF
--- a/PyTorch/Classification/ConvNets/triton/requirements.txt
+++ b/PyTorch/Classification/ConvNets/triton/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 networkx==2.5
-onnx==1.8.0
+onnx==1.13.0
 onnxruntime==1.5.2
 pycuda>=2019.1.2
 PyYAML>=5.2

--- a/PyTorch/Segmentation/nnUNet/triton/requirements.txt
+++ b/PyTorch/Segmentation/nnUNet/triton/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 networkx==2.5
-onnx==1.8.0
+onnx==1.13.0
 onnxruntime==1.5.2
 pycuda>=2019.1.2
 PyYAML>=5.2

--- a/PyTorch/SpeechSynthesis/FastPitch/triton/requirements.txt
+++ b/PyTorch/SpeechSynthesis/FastPitch/triton/requirements.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 networkx==2.5
 numpy
-onnx==1.8.0
+onnx==1.13.0
 onnxruntime==1.5.2
 pycuda>=2019.1.2
 PyYAML>=5.2

--- a/TensorFlow/Classification/ConvNets/triton/requirements.txt
+++ b/TensorFlow/Classification/ConvNets/triton/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 networkx==2.5
-onnx>=1.8.0
+onnx>=1.13.0
 onnxruntime>=1.9.0
 pycuda>=2019.1.2
 PyYAML>=5.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in onnx 1.8.0
- [CVE-2022-25882](https://www.oscs1024.com/hd/CVE-2022-25882)


### What did I do？
Upgrade onnx from 1.8.0 to 1.13.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS