### PR TITLE
fix(sec): upgrade gitpython to 3.1.35

### DIFF
--- a/PyTorch/LanguageModeling/BART/requirements.txt
+++ b/PyTorch/LanguageModeling/BART/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses
-gitpython==3.1.29
+gitpython==3.1.35
 rouge-score==0.1.2
 pynvml==8.0.4
 tqdm==4.64.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gitpython 3.1.29
- [CVE-2023-40267](https://www.oscs1024.com/hd/CVE-2023-40267)


### What did I do？
Upgrade gitpython from 3.1.29 to 3.1.35 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS