### PR TITLE
Bug fix in Pytorch nnUNet preprocessor.py

### DIFF
--- a/PyTorch/Segmentation/nnUNet/data_preprocessing/preprocessor.py
+++ b/PyTorch/Segmentation/nnUNet/data_preprocessing/preprocessor.py
@@ -217,7 +217,7 @@ class Preprocessor:
         spacing = np.array(spacing)
         target_spacing = np.median(spacing, axis=0)
         if max(target_spacing) / min(target_spacing) >= 3:
-            lowres_axis = np.argmin(target_spacing)
+            lowres_axis = np.argmax(target_spacing)
             target_spacing[lowres_axis] = np.percentile(spacing[:, lowres_axis], 10)
         self.target_spacing = list(target_spacing)
 


### PR DESCRIPTION
In PyTorch/Segmentation/nnUNet/data_preprocessing/preprocessor.py, line 220, you use the ```np.argmin``` function to find the low resolution axis for the target spacing variable. However, the low resolution axis is the position of the largest component of the target spacing. Hence, the ```np.argmax``` function is needed to find the low resolution axis.