### PR TITLE
Fix Tensorflow BURT Build

### DIFF
--- a/TensorFlow/LanguageModeling/BERT/Dockerfile
+++ b/TensorFlow/LanguageModeling/BERT/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE_NAME=nvcr.io/nvidia/tensorflow:20.06-tf1-py3
+ARG FROM_IMAGE_NAME=nvcr.io/nvidia/tensorflow:21.07-tf1-py3
 
 FROM ${FROM_IMAGE_NAME}
 


### PR DESCRIPTION
## Problem

Building the docker file in `TensorFlow/LanguageModeling/BERT` fails. This causes issues in one of the LaunchPad Labs.

- Step 10 fails `RUN pip3 install /workspace/pubmed_parser`
  - The error is `ERROR: Could not find a version that satisfies the requirement setuptools>=69.1`
  - This is an issue with the dependency at [https://github.com/titipata/pubmed_parser] mismatching with the TensorFlow 

## Solution

Update the TensorFlow image tag from `20.06-tf1-py3` to `21.07-tf1-py3` to resolve the problem

### Alternate Solution

Change line 13 of the Dockerfile to `RUN git clone --branch 0.4.0 https://github.com/titipata/pubmed_parser`

This solution is unideal since it uses an older release of the parser (current version is 0.5)

## Updates

Happy to make updates if needed

--Max
