### PR TITLE
Fix device mismatch when using non-default GPUs.

### DIFF
--- a/PyTorch/SpeechSynthesis/FastPitch/common/stft.py
+++ b/PyTorch/SpeechSynthesis/FastPitch/common/stft.py
@@ -123,7 +123,7 @@ class STFT(torch.nn.Module):
                 np.where(window_sum > tiny(window_sum))[0])
             window_sum = torch.autograd.Variable(
                 torch.from_numpy(window_sum), requires_grad=False)
-            window_sum = window_sum.cuda() if magnitude.is_cuda else window_sum
+            window_sum = window_sum.cuda(inverse_transform.get_device()) if magnitude.is_cuda else window_sum
             inverse_transform[:, :, approx_nonzero_indices] /= window_sum[approx_nonzero_indices]
 
             # scale by hop ratio


### PR DESCRIPTION
The `cuda` function will create the tensor on a default device that may differ from the device of tensor 'inverse_transform'.