### PR TITLE
workflows/cla - Bump contributor-assistant/github-action to v2.6.1

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: "DCO Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO Document and I hereby sign the DCO') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Looks like the current version here is not published to the GitHub Marketplace and fails to run

> contributor-assistant/github-action@v2.3.0 is not allowed to be used in NVIDIA/DeepLearningExamples. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, **verified in the GitHub Marketplace** ...

https://github.com/NVIDIA/DeepLearningExamples/actions/runs/11797445609

Bumping to the latest published version in https://github.com/marketplace/actions/cla-assistant-lite to resolve, see how v.2.3.0 is not available there